### PR TITLE
Set the AWS provider version to more loose

### DIFF
--- a/examples/aws_container_app/providers.tf
+++ b/examples/aws_container_app/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.1.0"
+      version = "~> 5.1"
     }
   }
 }


### PR DESCRIPTION
Set the AWS provider version in the example to not be explicitly hardcoded

```diff
- 5.1.0
+ ~> 5.1
```
