### PR TITLE
feat: add default security group

### DIFF
--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -22,6 +22,7 @@ module "port_ocean_ecs" {
   cluster_name                          = var.cluster_name
   existing_cluster_arn                  = var.existing_cluster_arn
   account_list_regions_resources_policy = var.account_list_regions_resources_policy
+  vpc_id = var.vpc_id
 
 
   lb_target_group_arn         = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].target_group_arn : ""

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -23,6 +23,7 @@ module "port_ocean_ecs" {
   existing_cluster_arn                  = var.existing_cluster_arn
   account_list_regions_resources_policy = var.account_list_regions_resources_policy
   vpc_id = var.vpc_id
+  create_default_sg = var.create_default_sg
 
 
   lb_target_group_arn         = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].target_group_arn : ""

--- a/modules/aws_helpers/ecs_service/variables.tf
+++ b/modules/aws_helpers/ecs_service/variables.tf
@@ -1,3 +1,14 @@
+variable "vpc_id" {
+  type        = string
+  description = "The LB VPC ID"
+}
+
+variable "create_default_sg" {
+  type        = bool
+  default     = true
+  description = "Whether to create a default security group"
+}
+
 variable "image_registry" {
   type        = string
   default     = "ghcr.io/port-labs"


### PR DESCRIPTION
Create a default security-group in case where there is no security group and the user marked the flag `create_default_sg` 