### PR TITLE
feat: Add additional task execution and task policy statements

### DIFF
--- a/examples/aws_container_app/README.MD
+++ b/examples/aws_container_app/README.MD
@@ -40,6 +40,46 @@ module "aws_integration" {
 }
 ```
 
+## Multi-Account Setup
+
+When setting up the integration in a multi-account environment, you can specify additional IAM policy statements to attach to the task role. This is useful when you need to assume roles in other accounts to access resources.
+
+```hcl
+module "aws_integration" {
+  source = "port-labs/integration-factory/ocean/examples/aws_container_app"
+  version = ">=0.0.24"
+
+  port = {
+    client_id     = "<client-id>"
+    client_secret = "<client-secret>"
+  }
+  integration = {
+    identifier = "my-aws-integration"
+    config = {
+      live_events_api_key = "<your-api-key>"
+      organization_role_arn  = "arn:.../organization-role"
+      account_read_role_name = "ocean-integration-role"
+    }
+  }
+  initialize_port_resources = true
+  allow_incoming_requests   = true
+  create_default_sg         = false
+  subnets                   = ["subnet-1", "subnet-2", "subnet-3"]
+  vpc_id                    = "vpc-1"
+  cluster_name              = "port-ocean-aws-exporter"
+
+  additional_task_policy_statements = [{
+    actions = ["sts:AssumeRole"]
+    resources = [
+      "arn:aws:iam::<root-account>:role/RootRole",
+      "arn:aws:iam::<member-account-1>:role/MemberRole",
+      "arn:aws:iam::<member-account-2>:role/MemberRole",
+      ...
+    ]
+}]
+}
+```
+
 ### Variables Explanation
 
 - `subnets`: List of subnet IDs where the ECS tasks will run.
@@ -54,6 +94,7 @@ module "aws_integration" {
 - `initialize_port_resources`: Boolean to initialize Port resources.
 - `create_default_sg`: Boolean to create a default security group.
 - `allow_incoming_requests`: Boolean to allow incoming requests to the ECS tasks.
+- `additional_task_policy_statements`: Additional IAM policy statements to attach to the task role.
 
 ### custom event creation
 

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -18,12 +18,14 @@ module "port_ocean_ecs_lb" {
 module "port_ocean_ecs" {
   source = "../../modules/aws_helpers/ecs_service"
 
-  subnets                               = var.subnets
-  cluster_name                          = var.cluster_name
-  existing_cluster_arn                  = var.existing_cluster_arn
-  account_list_regions_resources_policy = var.account_list_regions_resources_policy
-  vpc_id = var.vpc_id
-  create_default_sg = var.create_default_sg
+  subnets                                     = var.subnets
+  cluster_name                                = var.cluster_name
+  existing_cluster_arn                        = var.existing_cluster_arn
+  account_list_regions_resources_policy       = var.account_list_regions_resources_policy
+  vpc_id                                      = var.vpc_id
+  create_default_sg                           = var.create_default_sg
+  additional_task_execution_policy_statements = var.additional_task_execution_policy_statements
+  additional_task_policy_statements           = var.additional_task_policy_statements
 
 
   lb_target_group_arn         = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].target_group_arn : ""

--- a/examples/aws_container_app/variables.tf
+++ b/examples/aws_container_app/variables.tf
@@ -185,13 +185,22 @@ variable "lb_targ_group_arn" {
   default     = ""
   description = "The target group ARN"
 }
-variable "additional_policy_statements" {
+variable "additional_task_execution_policy_statements" {
   type = list(object({
     actions   = list(string)
     resources = list(string)
   }))
   default     = []
-  description = "Additional policy statements to attach to the task execution role"
+  description = "Additional policy statements to attach to the ECS service task execution role"
+}
+
+variable "additional_task_policy_statements" {
+  type = list(object({
+    actions   = list(string)
+    resources = list(string)
+  }))
+  default     = []
+  description = "Additional policy statements to attach to the ECS service task role"
 }
 
 variable "allow_incoming_requests" {

--- a/modules/aws_helpers/ecs_service/variables.tf
+++ b/modules/aws_helpers/ecs_service/variables.tf
@@ -144,13 +144,22 @@ variable "lb_target_group_arn" {
   default     = ""
   description = "The ARN of the target group to attach to the ECS service"
 }
-variable "additional_policy_statements" {
+variable "additional_task_execution_policy_statements" {
   type = list(object({
     actions   = list(string)
     resources = list(string)
   }))
   default     = []
-  description = "Additional policy statements to attach to the ECS service"
+  description = "Additional policy statements to attach to the ECS service task execution role"
+}
+
+variable "additional_task_policy_statements" {
+  type = list(object({
+    actions   = list(string)
+    resources = list(string)
+  }))
+  default     = []
+  description = "Additional policy statements to attach to the ECS service task role"
 }
 
 variable "allow_incoming_requests" {


### PR DESCRIPTION
This commit adds additional task execution and task policy statements to the AWS ECS service module. These statements allow for more fine-grained control over the permissions and actions that can be performed by the ECS service tasks.
