### PR TITLE
 Added scheduled_resync_interval to all ocean terraform modules

### DIFF
--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -37,6 +37,7 @@ module "port_ocean_ecs" {
 
   integration_version       = var.integration_version
   initialize_port_resources = var.initialize_port_resources
+  scheduled_resync_interval = var.scheduled_resync_interval
   event_listener            = var.event_listener
 
   integration = {

--- a/examples/aws_container_app/variables.tf
+++ b/examples/aws_container_app/variables.tf
@@ -165,6 +165,12 @@ variable "initialize_port_resources" {
   description = "Whether to initialize the port resources"
 }
 
+variable "scheduled_resync_interval" {
+  type        = number
+  default     = 60
+  description = "The interval to resync the integration"
+}
+
 variable "integration" {
   type = object({
     identifier = optional(string)

--- a/examples/aws_container_app/variables.tf
+++ b/examples/aws_container_app/variables.tf
@@ -167,8 +167,8 @@ variable "initialize_port_resources" {
 
 variable "scheduled_resync_interval" {
   type        = number
-  default     = 60
-  description = "The interval to resync the integration"
+  default     = 1440
+  description = "The interval to resync the integration (in minutes)"
 }
 
 variable "integration" {

--- a/examples/azure_container_app_azure_integration/variables.tf
+++ b/examples/azure_container_app_azure_integration/variables.tf
@@ -72,8 +72,8 @@ variable "initialize_port_resources" {
 
 variable "scheduled_resync_interval" {
     type = number
-    default = 60
-    description = "The interval to resync the integration"
+    default = 1440
+    description = "The interval to resync the integration (in minutes)"
 }
 
 variable "hosting_subscription_id" {

--- a/examples/azure_container_app_azure_integration/variables.tf
+++ b/examples/azure_container_app_azure_integration/variables.tf
@@ -70,6 +70,12 @@ variable "initialize_port_resources" {
     description = "If true, the module will initialize the default port resources (blueprints and relations)"
 }
 
+variable "scheduled_resync_interval" {
+    type = number
+    default = 60
+    description = "The interval to resync the integration"
+}
+
 variable "hosting_subscription_id" {
   type    = string
   default = null

--- a/examples/azure_container_app_generic/variables.tf
+++ b/examples/azure_container_app_generic/variables.tf
@@ -22,8 +22,8 @@ variable "initialize_port_resources" {
 
 variable "scheduled_resync_interval" {
     type = number
-    default = 60
-    description = "The interval to resync the integration"
+    default = 1440
+    description = "The interval to resync the integration (in minutes)"
 }
 
 variable "integration_identifier" {

--- a/examples/azure_container_app_generic/variables.tf
+++ b/examples/azure_container_app_generic/variables.tf
@@ -20,6 +20,12 @@ variable "initialize_port_resources" {
     description = "If true, the module will initialize the default port resources (blueprints and relations)"
 }
 
+variable "scheduled_resync_interval" {
+    type = number
+    default = 60
+    description = "The interval to resync the integration"
+}
+
 variable "integration_identifier" {
     type = string
     description = "The identifier of the integration"

--- a/examples/gcp_integration_with_real_time/main.tf
+++ b/examples/gcp_integration_with_real_time/main.tf
@@ -13,6 +13,10 @@ locals {
       value = var.initialize_port_resources ? "true" : "false"
     },
     {
+      name  = upper("OCEAN__SCHEDULED_RESYNC_INTERVAL"),
+      value = tostring(var.scheduled_resync_interval)
+    },
+    {
       name = upper("OCEAN__EVENT_LISTENER")
       value = jsonencode({
         for key, value in var.event_listener : key => value if value != null

--- a/examples/gcp_integration_with_real_time/variables.tf
+++ b/examples/gcp_integration_with_real_time/variables.tf
@@ -73,8 +73,8 @@ variable "initialize_port_resources" {
 
 variable "scheduled_resync_interval" {
   type        = number
-  default     = 60
-  description = "The interval to resync the integration"
+  default     = 1440
+  description = "The interval to resync the integration (in minutes)"
 }
 variable "event_listener" {
   type = object({

--- a/examples/gcp_integration_with_real_time/variables.tf
+++ b/examples/gcp_integration_with_real_time/variables.tf
@@ -70,6 +70,12 @@ variable "initialize_port_resources" {
   default     = true
   description = "If true, the module will create the port resources required for the integration"
 }
+
+variable "scheduled_resync_interval" {
+  type        = number
+  default     = 60
+  description = "The interval to resync the integration"
+}
 variable "event_listener" {
   type = object({
     type = string

--- a/modules/aws_helpers/ecs_service/main.tf
+++ b/modules/aws_helpers/ecs_service/main.tf
@@ -20,6 +20,10 @@ locals {
       value = var.initialize_port_resources ? "true" : "false"
     },
     {
+      name  = "OCEAN__SCHEDULED_RESYNC_INTERVAL",
+      value = tostring(var.scheduled_resync_interval)
+    },
+    {
       name = "OCEAN__EVENT_LISTENER"
       value = jsonencode({
         for key, value in var.event_listener : key => value if value != null

--- a/modules/aws_helpers/ecs_service/variables.tf
+++ b/modules/aws_helpers/ecs_service/variables.tf
@@ -126,8 +126,8 @@ variable "initialize_port_resources" {
 
 variable "scheduled_resync_interval" {
   type        = number
-  default     = 60
-  description = "The interval to resync the integration"
+  default     = 1440
+  description = "The interval to resync the integration (in minutes)"
 }
 
 variable "integration" {

--- a/modules/aws_helpers/ecs_service/variables.tf
+++ b/modules/aws_helpers/ecs_service/variables.tf
@@ -124,6 +124,12 @@ variable "initialize_port_resources" {
   description = "Whether to initialize the port resources"
 }
 
+variable "scheduled_resync_interval" {
+  type        = number
+  default     = 60
+  description = "The interval to resync the integration"
+}
+
 variable "integration" {
   type = object({
     identifier = optional(string)

--- a/modules/azure_container_app/container_app/main.tf
+++ b/modules/azure_container_app/container_app/main.tf
@@ -6,6 +6,10 @@ locals {
       value = var.initialize_port_resources ? "true" : "false"
     },
     {
+      name  = upper("OCEAN__SCHEDULED_RESYNC_INTERVAL"),
+      value = tostring(var.scheduled_resync_interval)
+    },
+    {
       name  = upper("OCEAN__EVENT_LISTENER")
       value = jsonencode({
         for key, value in var.event_listener : key => value if value != null

--- a/modules/azure_container_app/container_app/variables.tf
+++ b/modules/azure_container_app/container_app/variables.tf
@@ -53,8 +53,8 @@ variable "initialize_port_resources" {
 
 variable "scheduled_resync_interval" {
   type    = number
-  default = 60
-  description = "The interval to resync the integration"
+  default = 1440
+  description = "The interval to resync the integration (in minutes)"
 }
 
 variable "integration_version" {

--- a/modules/azure_container_app/container_app/variables.tf
+++ b/modules/azure_container_app/container_app/variables.tf
@@ -51,6 +51,12 @@ variable "initialize_port_resources" {
   description = "If true, the module will create the port resources required for the integration"
 }
 
+variable "scheduled_resync_interval" {
+  type    = number
+  default = 60
+  description = "The interval to resync the integration"
+}
+
 variable "integration_version" {
   type    = string
   default = "latest"

--- a/modules/azure_container_app/variables.tf
+++ b/modules/azure_container_app/variables.tf
@@ -53,8 +53,8 @@ variable "initialize_port_resources" {
 
 variable "scheduled_resync_interval" {
   type    = number
-  default = 60
-  description = "The interval to resync the integration"
+  default = 1440
+  description = "The interval to resync the integration (in minutes)"
 }
 
 variable "integration_version" {

--- a/modules/azure_container_app/variables.tf
+++ b/modules/azure_container_app/variables.tf
@@ -51,6 +51,12 @@ variable "initialize_port_resources" {
   description = "If true, the module will create the port resources required for the integration"
 }
 
+variable "scheduled_resync_interval" {
+  type    = number
+  default = 60
+  description = "The interval to resync the integration"
+}
+
 variable "integration_version" {
   type    = string
   default = "latest"


### PR DESCRIPTION
### Description 
The `scheduled_resync_interval` parameter has been added to the relevant modules (AWS, GCP, Azure). It introduces the necessary changes to allow users to configure the interval at which Ocean resources are automatically resynchronized.

