### PR TITLE
[GCP] | Conditionally create permissions resources (Bug Fix)

### DIFF
--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -92,6 +92,7 @@ module "port_ocean_authorization" {
   projects           = var.gcp_included_projects
   excluded_projects  = var.gcp_excluded_projects
   custom_roles       = var.ocean_service_account_custom_roles
+  create_service_account = var.create_service_account
 }
 module "port_ocean_pubsub" {
   source                     = "../../modules/gcp_helpers/pubsub"

--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -92,6 +92,7 @@ module "port_ocean_authorization" {
   projects           = var.gcp_included_projects
   excluded_projects  = var.gcp_excluded_projects
   custom_roles       = var.ocean_service_account_custom_roles
+  create_role        = var.create_role
   create_service_account = var.create_service_account
 }
 module "port_ocean_pubsub" {

--- a/examples/gcp_cloud_run/variables.tf
+++ b/examples/gcp_cloud_run/variables.tf
@@ -19,7 +19,7 @@ variable "gcp_organization" {
 }
 variable "gcp_ocean_setup_project" {
   type        = string
-  description = "The Project ot create all the Integration's infrastructure (Topic, Subscription, Service account etc.) on. Format - your-project-name"
+  description = "The Project to create all the Integration's infrastructure (Topic, Subscription, Service account etc.) on. Format - your-project-name"
 }
 variable "gcp_included_projects" {
   type        = list(string)
@@ -126,4 +126,10 @@ variable "ocean_service_account_custom_roles" {
   type        = list(string)
   description = "A list of custom roles you want to grant the Integration's Service account. The module will grant these permissions to every available project and to the setup project `gcp_ocean_setup_project`. Example value: [\"organizations/1234567890/roles/MyCustomRole\", \"organizations/1234567890/roles/MyOtherCustomRole\"]"
   default     = []
+}
+
+variable "create_service_account" {
+  type        = bool
+  description = "Determines whether to create a new service account. Set to `true` to create the service account, or `false` to use as existing service account."
+  default     = true
 }

--- a/examples/gcp_cloud_run/variables.tf
+++ b/examples/gcp_cloud_run/variables.tf
@@ -128,6 +128,12 @@ variable "ocean_service_account_custom_roles" {
   default     = []
 }
 
+variable "create_role" {
+  type        = bool
+  description = "Indicates whether Terraform should create a new organizational IAM role. Set to `true` to create the role, or `false` to use as existing organizational IAM role."
+  default     = true
+}
+
 variable "create_service_account" {
   type        = bool
   description = "Determines whether to create a new service account. Set to `true` to create the service account, or `false` to use as existing service account."

--- a/modules/gcp_helpers/authorization/main.tf
+++ b/modules/gcp_helpers/authorization/main.tf
@@ -8,6 +8,11 @@ data "google_service_account" "existing_service_account" {
   project    = var.project
 }
 
+data "google_iam_role" "existing_org_role" {
+  count      = var.create_role ? 0 : 1
+  name = format("organizations/%s/roles/%s", var.organization, var.role_id)
+}
+
 locals {
   has_specific_projects = length(var.projects) > 0
   has_excluded_projects = length(var.excluded_projects) > 0
@@ -29,7 +34,7 @@ locals {
 
   org_role_name = (var.create_role
     ? google_organization_iam_custom_role.ocean_integration_iam_org_role[0].name
-    : "organizations/${var.organization}/roles/${var.role_id}")
+    : data.google_iam_role.existing_org_role[0].name)
 
   service_account_email = (var.create_service_account
     ? google_service_account.ocean_integration_service_account[0].email

--- a/modules/gcp_helpers/authorization/main.tf
+++ b/modules/gcp_helpers/authorization/main.tf
@@ -27,6 +27,10 @@ locals {
     ]
   ]) : []
 
+  org_role_name = (var.create_role
+    ? google_organization_iam_custom_role.ocean_integration_iam_org_role[0].name
+    : "organizations/${var.organization}/roles/${var.role_id}")
+
   service_account_email = (var.create_service_account
     ? google_service_account.ocean_integration_service_account[0].email
     : data.google_service_account.existing_service_account[0].email
@@ -42,6 +46,7 @@ resource "google_service_account" "ocean_integration_service_account" {
 
 resource "google_organization_iam_custom_role" "ocean_integration_iam_org_role" {
   title       = "Ocean Integration organization role"
+  count       = var.create_role ? 1 : 0
   role_id     = var.role_id
   permissions = var.permissions
   org_id      = var.organization
@@ -50,7 +55,7 @@ resource "google_organization_iam_custom_role" "ocean_integration_iam_org_role" 
 resource "google_organization_iam_member" "ocean_integration_organization_iam_member" {
   count  = length(local.included_projects) == 0 ? 1 : 0
   org_id = var.organization
-  role   = google_organization_iam_custom_role.ocean_integration_iam_org_role.name
+  role   = local.org_role_name
   member = "serviceAccount:${local.service_account_email}"
 }
 
@@ -71,7 +76,7 @@ resource "google_organization_iam_custom_role" "setup_project_iam_org_role" {
 resource "google_project_iam_binding" "setup_project_role_binding" {
   count   = local.should_create_setup_role ? 1 : 0
   project = var.project
-  role    = google_organization_iam_custom_role.setup_project_iam_org_role[0].name
+  role   = local.org_role_name
 
   members = [
     "serviceAccount:${local.service_account_email}"
@@ -82,7 +87,7 @@ resource "google_project_iam_binding" "included_projects_role_binding" {
   count = length(local.included_projects)
 
   project = local.included_projects[count.index]
-  role    = google_organization_iam_custom_role.ocean_integration_iam_org_role.name
+  role    = local.org_role_name
 
   members = [
     "serviceAccount:${local.service_account_email}"

--- a/modules/gcp_helpers/authorization/outputs.tf
+++ b/modules/gcp_helpers/authorization/outputs.tf
@@ -1,9 +1,16 @@
 output "service_account_id" {
-  value = google_service_account.ocean_integration_service_account.id
+  description = "The ID of the service account."
+  value = (var.create_service_account
+    ? google_service_account.ocean_integration_service_account[0].id
+    : data.google_service_account.existing_service_account[0].id)
 }
 output "service_account_email" {
-  value = google_service_account.ocean_integration_service_account.email
+  description = "The email address of the service account being used."
+  value       = local.service_account_email
 }
 output "service_account_name" {
-  value = google_service_account.ocean_integration_service_account.account_id
+  description = "The account ID (name) of the service account."
+  value = (var.create_service_account
+    ? google_service_account.ocean_integration_service_account[0].account_id
+    : data.google_service_account.existing_service_account[0].account_id)
 }

--- a/modules/gcp_helpers/authorization/variables.tf
+++ b/modules/gcp_helpers/authorization/variables.tf
@@ -27,3 +27,9 @@ variable "custom_roles" {
   type    = list(string)
   default = []
 }
+
+variable "create_service_account" {
+  type        = bool
+  description = "Flag to indicate whether or not to create a service account"
+  default     = false
+}

--- a/modules/gcp_helpers/authorization/variables.tf
+++ b/modules/gcp_helpers/authorization/variables.tf
@@ -37,5 +37,5 @@ variable "create_role" {
 variable "create_service_account" {
   type        = bool
   description = "Flag to indicate whether or not to create a service account"
-  default     = false
+  default     = true
 }

--- a/modules/gcp_helpers/authorization/variables.tf
+++ b/modules/gcp_helpers/authorization/variables.tf
@@ -28,6 +28,12 @@ variable "custom_roles" {
   default = []
 }
 
+variable "create_role" {
+  type        = bool
+  description = "Whether to create the organizational role"
+  default     = true
+}
+
 variable "create_service_account" {
   type        = bool
   description = "Flag to indicate whether or not to create a service account"


### PR DESCRIPTION
**PR Description:**

- Added flags to enable conditionally creating service account and org role resources, if service account or role already exists, the `create_service_account` or `create_role` flags can be set to false, the plan will skip creating these resources


What I have Tested:
- [x] Ensured that service account flag create_service_account properly  controls creating and skipping gcp service accounts
- [x] Ensured that org role flag create_service_account properly  controls creating and skipping GCP organizational role
- [x] When Terraform sees that the resource is no longer in the configuration (when flag -> false,  count = 0,  this behavior is automatically enforced), It plans to destroy the resource because it's no longer defined the  Terraform code. I've run a tests to ensure that create_role = false and create_service_account = false do not delete existing org role since count evaluates to 0 (yesterday's last test)