### PR TITLE
[GCP] | Enforce independent resource provisioning per environment

### DIFF
--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -52,7 +52,10 @@ locals {
       })
     }
   ]
-  feed_topic_id = var.assets_feed_topic_id != null ? var.assets_feed_topic_id : "ocean-integration-topic"
+  resource_id_prefix = "${var.integration_identifier}-${var.environment}"
+  feed_topic_id = coalesce(var.assets_feed_topic_id, "${local.resource_id_prefix}-topic")
+  assets_feed_id = coalesce(var.assets_feed_id, "${local.resource_id_prefix}-assets-feed")
+
   permissions = var.ocean_integration_service_account_permissions != null ? var.ocean_integration_service_account_permissions : ["cloudasset.assets.exportResource",
     "cloudasset.assets.listCloudAssetFeeds",
     "cloudasset.assets.listResource",
@@ -79,8 +82,22 @@ locals {
     "pubsub.googleapis.com/Subscription",
     "pubsub.googleapis.com/Topic"
   ]
-  service_account_id = var.service_account_name != null ? var.service_account_name : "ocean-service-account"
-  role_id            = var.role_name != null ? var.role_name : "OceanIntegrationRole"
+
+  service_account_id  = coalesce(var.service_account_name, "${local.resource_id_prefix}-service-account")
+  role_id = coalesce(
+    var.role_name,
+    format(
+      "%sRole",
+      replace(
+        title(replace(local.resource_id_prefix, "-", " ")),
+        " ",
+        ""
+      )
+    )
+  )
+  cloud_run_service_name = coalesce(var.cloud_run_service_name, "${local.resource_id_prefix}-service")
+
+
 }
 module "port_ocean_authorization" {
   source             = "../../modules/gcp_helpers/authorization"
@@ -107,20 +124,23 @@ module "port_ocean_assets_feed" {
   source             = "../../modules/gcp_helpers/assets_feed"
   feed_topic_project = var.gcp_ocean_setup_project
   billing_project    = var.gcp_ocean_setup_project
-  assets_feed_id     = var.assets_feed_id
+  assets_feed_id     = local.assets_feed_id
   projects           = var.gcp_included_projects
   feed_topic         = module.port_ocean_pubsub.ocean_topic_name
   organization       = var.gcp_organization
   asset_types        = local.asset_types
   depends_on         = [module.port_ocean_cloud_run]
+  integration_identifier = local.resource_id_prefix
   excluded_projects  = var.gcp_excluded_projects
 }
 resource "time_sleep" "wait_for_authentication_to_take_affect" {
   depends_on      = [module.port_ocean_authorization]
   create_duration = "180s"
 }
+
 module "port_ocean_cloud_run" {
   source                = "../../modules/gcp_helpers/cloud_run"
+  cloud_run_service_name = local.cloud_run_service_name
   service_account_name  = module.port_ocean_authorization.service_account_name
   environment_variables = local.envs
   project               = var.gcp_ocean_setup_project

--- a/examples/gcp_cloud_run/variables.tf
+++ b/examples/gcp_cloud_run/variables.tf
@@ -39,13 +39,17 @@ variable "ocean_integration_service_account_permissions" {
   type    = list(string)
   default = null
 }
+variable "cloud_run_service_name" {
+  type = string
+  default = null
+}
 variable "assets_feed_topic_id" {
   type    = string
   default = null
 }
 variable "assets_feed_id" {
   type        = string
-  default     = "ocean-gcp-integration-assets-feed"
+  default     = null
   description = "The ID for the Ocean GCP Integration feed"
 }
 variable "service_account_name" {
@@ -138,4 +142,9 @@ variable "create_service_account" {
   type        = bool
   description = "Determines whether to create a new service account. Set to `true` to create the service account, or `false` to use as existing service account."
   default     = true
+}
+variable "environment" {
+  type        = string
+  description = "The environment for the integration (e.g., 'stg', 'prod')"
+  default = "prod"
 }


### PR DESCRIPTION
**Issue:**  
When executing `terraform apply` with project feeds that already exist within the GCP account, Terraform fails and returns an error stating that the feed already exists.

**Solution:**  
To prevent such errors and enhance support for multi deployments, We Introduce an extra variable `environment` that prefixes the resources identifiers, enforcing unique identifier per deployment and preventing the duplication error.

**Changes Include:**
- Enhanced support for multi deployment setups by adding an extra variable `environment`. (e.g stg, prod)`
- Updated default naming convention to utilize the given `integration_name` and `environment`.
 e.g `my-gcp-integration-prod`, `my-gcp-integration-stg`,`my-gcp-integration-dev` 

**Benefits:**
- Prevents Terraform from failing due to duplicate feed errors.
- Allows for smoother integration with pre-existing GCP asset feeds.
- Easy identification of integration resources due to the consistent naming convention between Port and GCP integration

**Testing:**  
Verified that `terraform apply` successfully skips the creation of existing feeds and applies changes without errors.