### PR TITLE
[Integration][GCP] | Optionally Filter GCP Projects by Label

### DIFF
--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -90,6 +90,7 @@ module "port_ocean_authorization" {
   organization       = var.gcp_organization
   project            = var.gcp_ocean_setup_project
   projects           = var.gcp_included_projects
+  project_label_filter = var.gcp_project_label_filter
   excluded_projects  = var.gcp_excluded_projects
   custom_roles       = var.ocean_service_account_custom_roles
   create_role        = var.create_role
@@ -114,6 +115,7 @@ module "port_ocean_assets_feed" {
   asset_types        = local.asset_types
   depends_on         = [module.port_ocean_cloud_run]
   excluded_projects  = var.gcp_excluded_projects
+  project_label_filter = var.gcp_project_label_filter
 }
 resource "time_sleep" "wait_for_authentication_to_take_affect" {
   depends_on      = [module.port_ocean_authorization]

--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -90,7 +90,7 @@ module "port_ocean_authorization" {
   organization       = var.gcp_organization
   project            = var.gcp_ocean_setup_project
   projects           = var.gcp_included_projects
-  project_label_filter = var.gcp_project_label_filter
+  project_label_filters = var.gcp_project_label_filters
   excluded_projects  = var.gcp_excluded_projects
   custom_roles       = var.ocean_service_account_custom_roles
   create_role        = var.create_role
@@ -115,7 +115,7 @@ module "port_ocean_assets_feed" {
   asset_types        = local.asset_types
   depends_on         = [module.port_ocean_cloud_run]
   excluded_projects  = var.gcp_excluded_projects
-  project_label_filter = var.gcp_project_label_filter
+  project_label_filters = var.gcp_project_label_filters
 }
 resource "time_sleep" "wait_for_authentication_to_take_affect" {
   depends_on      = [module.port_ocean_authorization]

--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -81,7 +81,7 @@ locals {
   ]
   service_account_id = var.service_account_name != null ? var.service_account_name : "ocean-service-account"
   role_id            = var.role_name != null ? var.role_name : "OceanIntegrationRole"
-  poject_filter  = coalesce(var.gcp_project_filter, "parent.id=${var.gcp_organization}")
+  project_filter  = coalesce(var.gcp_project_filter, "parent.id=${var.gcp_organization}")
 }
 module "port_ocean_authorization" {
   source             = "../../modules/gcp_helpers/authorization"
@@ -91,7 +91,7 @@ module "port_ocean_authorization" {
   organization       = var.gcp_organization
   project            = var.gcp_ocean_setup_project
   projects           = var.gcp_included_projects
-  project_filter     = local.poject_filter
+  project_filter     = local.project_filter
   excluded_projects  = var.gcp_excluded_projects
   custom_roles       = var.ocean_service_account_custom_roles
   create_role        = var.create_role
@@ -115,7 +115,7 @@ module "port_ocean_assets_feed" {
   organization       = var.gcp_organization
   asset_types        = local.asset_types
   excluded_projects  = var.gcp_excluded_projects
-  project_filter     = local.poject_filter
+  project_filter     = local.project_filter
 }
 resource "time_sleep" "wait_for_authentication_to_take_affect" {
   depends_on      = [module.port_ocean_authorization]

--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -81,6 +81,7 @@ locals {
   ]
   service_account_id = var.service_account_name != null ? var.service_account_name : "ocean-service-account"
   role_id            = var.role_name != null ? var.role_name : "OceanIntegrationRole"
+  poject_filter  = coalesce(var.gcp_project_filter, "parent.id=${var.gcp_organization}")
 }
 module "port_ocean_authorization" {
   source             = "../../modules/gcp_helpers/authorization"
@@ -90,7 +91,7 @@ module "port_ocean_authorization" {
   organization       = var.gcp_organization
   project            = var.gcp_ocean_setup_project
   projects           = var.gcp_included_projects
-  project_label_filters = var.gcp_project_label_filters
+  project_filter     = local.poject_filter
   excluded_projects  = var.gcp_excluded_projects
   custom_roles       = var.ocean_service_account_custom_roles
   create_role        = var.create_role
@@ -114,7 +115,7 @@ module "port_ocean_assets_feed" {
   organization       = var.gcp_organization
   asset_types        = local.asset_types
   excluded_projects  = var.gcp_excluded_projects
-  project_label_filters = var.gcp_project_label_filters
+  project_filter     = local.poject_filter
 }
 resource "time_sleep" "wait_for_authentication_to_take_affect" {
   depends_on      = [module.port_ocean_authorization]

--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -113,7 +113,7 @@ module "port_ocean_assets_feed" {
   feed_topic         = module.port_ocean_pubsub.ocean_topic_name
   organization       = var.gcp_organization
   asset_types        = local.asset_types
-  depends_on         = [module.port_ocean_cloud_run]
+  # depends_on         = [module.port_ocean_cloud_run]
   excluded_projects  = var.gcp_excluded_projects
   project_label_filters = var.gcp_project_label_filters
 }

--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -113,7 +113,6 @@ module "port_ocean_assets_feed" {
   feed_topic         = module.port_ocean_pubsub.ocean_topic_name
   organization       = var.gcp_organization
   asset_types        = local.asset_types
-  # depends_on         = [module.port_ocean_cloud_run]
   excluded_projects  = var.gcp_excluded_projects
   project_label_filters = var.gcp_project_label_filters
 }

--- a/examples/gcp_cloud_run/variables.tf
+++ b/examples/gcp_cloud_run/variables.tf
@@ -27,12 +27,10 @@ variable "gcp_included_projects" {
   default     = []
 }
 
-variable "gcp_project_label_filter" {
-  description = "Map containing the label key and value to filter projects"
-  type        = object({
-    key   = string
-    value = string
-  })
+variable "gcp_project_label_filters" {
+  description = "Optional map of label key-value pairs to filter projects"
+  type        = map(string)
+  default     = {}
 }
 
 variable "gcp_excluded_projects" {

--- a/examples/gcp_cloud_run/variables.tf
+++ b/examples/gcp_cloud_run/variables.tf
@@ -36,7 +36,7 @@ variable "gcp_project_label_filters" {
 variable "gcp_project_filter" {
   description = <<-EOT
     The filter string used to retrieve GCP projects, allowing complex filtering by combining multiple conditions with logical operators (AND | OR). Follows GCP's [filter expressions syntax](https://cloud.google.com/sdk/gcloud/reference/topic/filters). e.g.
-    labels.environment:production AND labels.team:devops
+    project.id: labels.environment:production AND labels.team:devops
     OR
     labels.priority:high
   EOT

--- a/examples/gcp_cloud_run/variables.tf
+++ b/examples/gcp_cloud_run/variables.tf
@@ -33,6 +33,17 @@ variable "gcp_project_label_filters" {
   default     = {}
 }
 
+variable "gcp_project_filter" {
+  description = <<-EOT
+    The filter string used to retrieve GCP projects, allowing complex filtering by combining multiple conditions with logical operators (AND | OR). Follows GCP's [filter expressions syntax](https://cloud.google.com/sdk/gcloud/reference/topic/filters). e.g.
+    labels.environment:production AND labels.team:devops
+    OR
+    labels.priority:high
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "gcp_excluded_projects" {
   type        = list(string)
   description = "The Projects list you want the integration NOT to collect from"

--- a/examples/gcp_cloud_run/variables.tf
+++ b/examples/gcp_cloud_run/variables.tf
@@ -36,7 +36,7 @@ variable "gcp_project_label_filters" {
 variable "gcp_project_filter" {
   description = <<-EOT
     The filter string used to retrieve GCP projects, allowing complex filtering by combining multiple conditions with logical operators (AND | OR). Follows GCP's [filter expressions syntax](https://cloud.google.com/sdk/gcloud/reference/topic/filters). e.g.
-    project.id: labels.environment:production AND labels.team:devops
+    parent.id:184606565139 labels.environment:production AND labels.team:devops
     OR
     labels.priority:high
   EOT

--- a/examples/gcp_cloud_run/variables.tf
+++ b/examples/gcp_cloud_run/variables.tf
@@ -26,6 +26,15 @@ variable "gcp_included_projects" {
   description = "The Projects list you want the integration to collect from"
   default     = []
 }
+
+variable "gcp_project_label_filter" {
+  description = "Map containing the label key and value to filter projects"
+  type        = object({
+    key   = string
+    value = string
+  })
+}
+
 variable "gcp_excluded_projects" {
   type        = list(string)
   description = "The Projects list you want the integration NOT to collect from"

--- a/modules/gcp_helpers/assets_feed/main.tf
+++ b/modules/gcp_helpers/assets_feed/main.tf
@@ -1,5 +1,13 @@
 data "google_projects" "all" {
-  filter = var.project_label_filter != null ? "parent.id:'${var.organization}' labels.${var.project_label_filter.key}:${var.project_label_filter.value}" : "parent.id:'${var.organization}'"
+  filter = join(" ", compact([
+    "parent.type:organization parent.id:${var.organization}",
+    length(var.project_label_filters) > 0 ? (
+      join(" ", [
+        for k, v in var.project_label_filters : 
+        "labels.${k}=${v}"
+      ])
+    ) : ""
+  ]))
 }
 
 

--- a/modules/gcp_helpers/assets_feed/main.tf
+++ b/modules/gcp_helpers/assets_feed/main.tf
@@ -1,13 +1,5 @@
 data "google_projects" "all" {
-  filter = join(" ", compact([
-    "parent.id:${var.organization}",
-    length(var.project_label_filters) > 0 ? (
-      join(" ", [
-        for k, v in var.project_label_filters : 
-        "labels.${k}:${v}"
-      ])
-    ) : ""
-  ]))
+  filter = var.project_filter
 }
 
 

--- a/modules/gcp_helpers/assets_feed/main.tf
+++ b/modules/gcp_helpers/assets_feed/main.tf
@@ -1,8 +1,11 @@
 data "google_projects" "all" {
-  filter = "parent.id=${var.organization}"
+  filter = local.project_filter
 }
 
 locals {
+  label_filter = var.project_label_filter != null ? " labels.${var.project_label_filter.key}:${var.project_label_filter.value}" : ""
+  project_filter = "parent.id:'${var.organization}'${local.label_filter}"
+  
   has_specific_projects = length(var.projects) > 0
   has_excluded_projects = length(var.excluded_projects) > 0
   filtered_projects     = local.has_excluded_projects ? [for project in data.google_projects.all.projects : project.project_id if !contains(var.excluded_projects, project.project_id)] : []

--- a/modules/gcp_helpers/assets_feed/main.tf
+++ b/modules/gcp_helpers/assets_feed/main.tf
@@ -1,11 +1,9 @@
 data "google_projects" "all" {
-  filter = local.project_filter
+  filter = var.project_label_filter != null ? "parent.id:'${var.organization}' labels.${var.project_label_filter.key}:${var.project_label_filter.value}" : "parent.id:'${var.organization}'"
 }
 
+
 locals {
-  label_filter = var.project_label_filter != null ? " labels.${var.project_label_filter.key}:${var.project_label_filter.value}" : ""
-  project_filter = "parent.id:'${var.organization}'${local.label_filter}"
-  
   has_specific_projects = length(var.projects) > 0
   has_excluded_projects = length(var.excluded_projects) > 0
   filtered_projects     = local.has_excluded_projects ? [for project in data.google_projects.all.projects : project.project_id if !contains(var.excluded_projects, project.project_id)] : []

--- a/modules/gcp_helpers/assets_feed/variables.tf
+++ b/modules/gcp_helpers/assets_feed/variables.tf
@@ -32,8 +32,13 @@ variable "excluded_projects" {
   default = []
 }
 
-variable "project_label_filters" {
-  description = "Optional map of label key-value pairs to filter projects"
-  type        = map(string)
-  default     = {}
+variable "project_filter" {
+  description = <<-EOT
+    The filter string used to retrieve GCP projects, allowing complex filtering by combining multiple conditions with logical operators (AND | OR). Follows GCP's [filter expressions syntax](https://cloud.google.com/sdk/gcloud/reference/topic/filters). e.g.
+    labels.environment:production AND labels.team:devops
+    OR
+    labels.priority:high
+  EOT
+  type        = string
+  default     = null
 }

--- a/modules/gcp_helpers/assets_feed/variables.tf
+++ b/modules/gcp_helpers/assets_feed/variables.tf
@@ -35,7 +35,7 @@ variable "excluded_projects" {
 variable "project_filter" {
   description = <<-EOT
     The filter string used to retrieve GCP projects, allowing complex filtering by combining multiple conditions with logical operators (AND | OR). Follows GCP's [filter expressions syntax](https://cloud.google.com/sdk/gcloud/reference/topic/filters). e.g.
-    labels.environment:production AND labels.team:devops
+    parent.id:184606565139 labels.environment:production AND labels.team:devops
     OR
     labels.priority:high
   EOT

--- a/modules/gcp_helpers/assets_feed/variables.tf
+++ b/modules/gcp_helpers/assets_feed/variables.tf
@@ -32,11 +32,8 @@ variable "excluded_projects" {
   default = []
 }
 
-
-variable "project_label_filter" {
-  description = "Map containing the label key and value to filter projects"
-  type        = object({
-    key   = string
-    value = string
-  })
+variable "project_label_filters" {
+  description = "Optional map of label key-value pairs to filter projects"
+  type        = map(string)
+  default     = {}
 }

--- a/modules/gcp_helpers/assets_feed/variables.tf
+++ b/modules/gcp_helpers/assets_feed/variables.tf
@@ -31,3 +31,12 @@ variable "excluded_projects" {
   type    = list(string)
   default = []
 }
+
+
+variable "project_label_filter" {
+  description = "Map containing the label key and value to filter projects"
+  type        = object({
+    key   = string
+    value = string
+  })
+}

--- a/modules/gcp_helpers/authorization/main.tf
+++ b/modules/gcp_helpers/authorization/main.tf
@@ -1,5 +1,6 @@
 data "google_projects" "all" {
-  filter = local.project_filter
+  filter = var.project_label_filter != null ? "parent.id:'${var.organization}' labels.${var.project_label_filter.key}:${var.project_label_filter.value}" : "parent.id:'${var.organization}'"
+
 }
 
 data "google_service_account" "existing_service_account" {
@@ -14,9 +15,6 @@ data "google_iam_role" "existing_org_role" {
 }
 
 locals {
-  label_filter = var.project_label_filter != null ? " labels.${var.project_label_filter.key}:${var.project_label_filter.value}" : ""
-  project_filter = "parent.id:'${var.organization}'${local.label_filter}"
-
   has_specific_projects = length(var.projects) > 0
   has_excluded_projects = length(var.excluded_projects) > 0
   filtered_projects     = local.has_excluded_projects ? [for project in data.google_projects.all.projects : project.project_id if !contains(var.excluded_projects, project.project_id)] : []

--- a/modules/gcp_helpers/authorization/main.tf
+++ b/modules/gcp_helpers/authorization/main.tf
@@ -1,10 +1,10 @@
 data "google_projects" "all" {
   filter = join(" ", compact([
-    "parent.type:organization parent.id:${var.organization}",
+    "parent.id:${var.organization}",
     length(var.project_label_filters) > 0 ? (
       join(" ", [
         for k, v in var.project_label_filters : 
-        "labels.${k}=${v}"
+        "labels.${k}:${v}"
       ])
     ) : ""
   ]))
@@ -24,8 +24,9 @@ data "google_iam_role" "existing_org_role" {
 locals {
   has_specific_projects = length(var.projects) > 0
   has_excluded_projects = length(var.excluded_projects) > 0
-  filtered_projects     = local.has_excluded_projects ? [for project in data.google_projects.all.projects : project.project_id if !contains(var.excluded_projects, project.project_id)] : []
-  included_projects     = local.has_specific_projects ? var.projects : (local.has_excluded_projects ? local.filtered_projects : [])
+  filtered_projects     = local.has_excluded_projects ? [for project in data.google_projects.all.projects : project.project_id if !contains(var.excluded_projects, project.project_id)] : [for project in data.google_projects.all.projects : project.project_id]
+
+  included_projects = local.has_specific_projects ? var.projects : local.filtered_projects
 
   should_create_setup_role  = length(local.included_projects) > 0 && !contains(local.included_projects, var.project)
   get_project_permissions   = ["resourcemanager.projects.get", "resourcemanager.projects.list"]

--- a/modules/gcp_helpers/authorization/main.tf
+++ b/modules/gcp_helpers/authorization/main.tf
@@ -1,5 +1,5 @@
 data "google_projects" "all" {
-  filter = "parent.id=${var.organization}"
+  filter = local.project_filter
 }
 
 data "google_service_account" "existing_service_account" {
@@ -14,6 +14,9 @@ data "google_iam_role" "existing_org_role" {
 }
 
 locals {
+  label_filter = var.project_label_filter != null ? " labels.${var.project_label_filter.key}:${var.project_label_filter.value}" : ""
+  project_filter = "parent.id:'${var.organization}'${local.label_filter}"
+
   has_specific_projects = length(var.projects) > 0
   has_excluded_projects = length(var.excluded_projects) > 0
   filtered_projects     = local.has_excluded_projects ? [for project in data.google_projects.all.projects : project.project_id if !contains(var.excluded_projects, project.project_id)] : []

--- a/modules/gcp_helpers/authorization/main.tf
+++ b/modules/gcp_helpers/authorization/main.tf
@@ -1,6 +1,13 @@
 data "google_projects" "all" {
-  filter = var.project_label_filter != null ? "parent.id:'${var.organization}' labels.${var.project_label_filter.key}:${var.project_label_filter.value}" : "parent.id:'${var.organization}'"
-
+  filter = join(" ", compact([
+    "parent.type:organization parent.id:${var.organization}",
+    length(var.project_label_filters) > 0 ? (
+      join(" ", [
+        for k, v in var.project_label_filters : 
+        "labels.${k}=${v}"
+      ])
+    ) : ""
+  ]))
 }
 
 data "google_service_account" "existing_service_account" {

--- a/modules/gcp_helpers/authorization/main.tf
+++ b/modules/gcp_helpers/authorization/main.tf
@@ -1,13 +1,5 @@
 data "google_projects" "all" {
-  filter = join(" ", compact([
-    "parent.id:${var.organization}",
-    length(var.project_label_filters) > 0 ? (
-      join(" ", [
-        for k, v in var.project_label_filters : 
-        "labels.${k}:${v}"
-      ])
-    ) : ""
-  ]))
+  filter = var.project_filter
 }
 
 data "google_service_account" "existing_service_account" {

--- a/modules/gcp_helpers/authorization/variables.tf
+++ b/modules/gcp_helpers/authorization/variables.tf
@@ -23,12 +23,10 @@ variable "excluded_projects" {
   default = []
 }
 
-variable "project_label_filter" {
-  description = "Map containing the label key and value to filter projects"
-  type        = object({
-    key   = string
-    value = string
-  })
+variable "project_label_filters" {
+  description = "Optional map of label key-value pairs to filter projects"
+  type        = map(string)
+  default     = {}
 }
 
 variable "custom_roles" {

--- a/modules/gcp_helpers/authorization/variables.tf
+++ b/modules/gcp_helpers/authorization/variables.tf
@@ -23,10 +23,15 @@ variable "excluded_projects" {
   default = []
 }
 
-variable "project_label_filters" {
-  description = "Optional map of label key-value pairs to filter projects"
-  type        = map(string)
-  default     = {}
+variable "project_filter" {
+  description = <<-EOT
+    The filter string used to retrieve GCP projects, allowing complex filtering by combining multiple conditions with logical operators (AND | OR). Follows GCP's [filter expressions syntax](https://cloud.google.com/sdk/gcloud/reference/topic/filters). e.g.
+    parent.id:184606565139 labels.environment:production AND labels.team:devops
+    OR
+    labels.priority:high
+  EOT
+  type        = string
+  default     = null
 }
 
 variable "custom_roles" {

--- a/modules/gcp_helpers/authorization/variables.tf
+++ b/modules/gcp_helpers/authorization/variables.tf
@@ -23,6 +23,14 @@ variable "excluded_projects" {
   default = []
 }
 
+variable "project_label_filter" {
+  description = "Map containing the label key and value to filter projects"
+  type        = object({
+    key   = string
+    value = string
+  })
+}
+
 variable "custom_roles" {
   type    = list(string)
   default = []


### PR DESCRIPTION
## Description

This pull request introduces a variable to enable optionally filtering by a specific project label. This enhancement allows users to list projects under an organization, with the flexibility to apply a label filter if desired.

## Changes

- **Project Filtering:**
  - **Variables:**
    - `organization_id` (required): The GCP organization ID.
    - `project_label_filter` (optional): An object with `key` and `value` for label-based filtering.
  - **Data Source:**
    - Uses `google_projects` to retrieve projects based on the provided filters.
  - **Logic:**
    - Dynamically constructs the filter string to include the label filter only if it's provided.
  - **Output:**
    - Outputs the IDs of the filtered projects.

## Usage

1. **Set Provider Credentials:**
   - Update the provider configuration with your GCP credentials, project ID, and region.

2. **Define Variables:**
   - In your `terraform.tfvars` file or via command-line arguments, set the `organization_id`.
   - Optionally, set `project_label_filter` if you wish to filter by a project label.

   **Example with Label Filter:**

   ```hcl
   organization_id = "123456789012"
   project_label_filter = {
     key   = "environment"
     value = "production"
   }
   ```

   **Example without Label Filter:**

   ```hcl
   organization_id = "123456789012"
   # project_label_filter is not set
   ```

3. **Run Terraform Commands:**

   ```bash
   terraform init
   terraform apply
   ```

## Notes

- **Optional Label Filter:**
  - If `project_label_filter` is not provided, the script retrieves all projects under the specified organization ID.
- **Permissions:**
  - Ensure that your credentials have permission to list projects in the organization.
- **API Enablement:**
  - The Resource Manager API must be enabled in your GCP project.