### PR TITLE
Restore Organization-Level Asset Feeds and Roles Creation When No Projects Are Specified

### DIFF
--- a/examples/gcp_cloud_run/main.tf
+++ b/examples/gcp_cloud_run/main.tf
@@ -81,7 +81,6 @@ locals {
   ]
   service_account_id = var.service_account_name != null ? var.service_account_name : "ocean-service-account"
   role_id            = var.role_name != null ? var.role_name : "OceanIntegrationRole"
-  project_filter  = coalesce(var.gcp_project_filter, "parent.id=${var.gcp_organization}")
 }
 module "port_ocean_authorization" {
   source             = "../../modules/gcp_helpers/authorization"
@@ -91,7 +90,7 @@ module "port_ocean_authorization" {
   organization       = var.gcp_organization
   project            = var.gcp_ocean_setup_project
   projects           = var.gcp_included_projects
-  project_filter     = local.project_filter
+  project_filter     = var.gcp_project_filter
   excluded_projects  = var.gcp_excluded_projects
   custom_roles       = var.ocean_service_account_custom_roles
   create_role        = var.create_role
@@ -115,7 +114,7 @@ module "port_ocean_assets_feed" {
   organization       = var.gcp_organization
   asset_types        = local.asset_types
   excluded_projects  = var.gcp_excluded_projects
-  project_filter     = local.project_filter
+  project_filter     = var.gcp_project_filter
 }
 resource "time_sleep" "wait_for_authentication_to_take_affect" {
   depends_on      = [module.port_ocean_authorization]

--- a/modules/gcp_helpers/assets_feed/main.tf
+++ b/modules/gcp_helpers/assets_feed/main.tf
@@ -1,14 +1,15 @@
 data "google_projects" "all" {
-  filter = var.project_filter
+  filter =  coalesce(var.project_filter, "parent.id=${var.organization}")
 }
 
 
 locals {
   has_specific_projects = length(var.projects) > 0
   has_excluded_projects = length(var.excluded_projects) > 0
+  has_project_filter    = var.project_filter != null
   filtered_projects     = local.has_excluded_projects ? [for project in data.google_projects.all.projects : project.project_id if !contains(var.excluded_projects, project.project_id)] : [for project in data.google_projects.all.projects : project.project_id]
 
-  included_projects = local.has_specific_projects ? var.projects : local.filtered_projects
+  included_projects = local.has_specific_projects ? var.projects : (local.has_project_filter ? local.filtered_projects : [])
 }
 
 resource "google_cloud_asset_organization_feed" "ocean_integration_assets_feed" {


### PR DESCRIPTION
Description

This PR restores the original behavior where, if no specific projects are included, the script creates organization-level asset feeds and roles. This change prevents the overhead of making iterative API calls to create asset feeds and roles for each individual project within the organization.

By handling asset feeds and roles at the organization level when no projects are specified, we improve efficiency, reduce API usage, and streamline resource management.