### PR TITLE
Add functional for "assign_public_ip" variable flag

### DIFF
--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -26,6 +26,7 @@ module "port_ocean_ecs" {
   create_default_sg                           = var.create_default_sg
   additional_task_execution_policy_statements = var.additional_task_execution_policy_statements
   additional_task_policy_statements           = var.additional_task_policy_statements
+  assign_public_ip                            = var.assign_public_ip
 
 
   lb_target_group_arn         = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].target_group_arn : ""


### PR DESCRIPTION
The helper module that port_ocean_ecs loads allowed for a "assign_public_ip" variable. 

However this not carried forward in the aws_container_app module despite the fact that it also has a "assign_public_ip" variable. This PR just makes use of that variable so users can not assign public ips to port 