### PR TITLE
[Fix] Adding Tags and implmenting Vars: create_egress_default_sg, create_default_sg, assign_public_ip, container_port

### DIFF
--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -22,7 +22,7 @@ module "port_ocean_ecs_lb" {
 
 module "port_ocean_ecs" {
   source = "../../modules/aws_helpers/ecs_service"
-
+  depends_on = [ module.port_ocean_ecs_lb ]
   subnets                                     = var.subnets
   create_ecs_cluster                          = var.create_ecs_cluster
   existing_cluster_arn                        = var.existing_cluster_arn

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -59,7 +59,7 @@ module "port_ocean_ecs" {
 
 module "api_gateway" {
   source = "../../modules/aws_helpers/api_gateway"
-  count  = var.allow_incoming_requests ? 1 : 0
+  count  = var.allow_incoming_requests && var.enable_apigw ? 1 : 0
 
   webhook_url = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].dns_name : ""
   tags        = var.tags
@@ -68,7 +68,7 @@ module "api_gateway" {
 # TODO: implment Tags for this module
 module "events" {
   source = "../../modules/aws_helpers/default_events"
-  count  = var.allow_incoming_requests ? 1 : 0
+  count  = var.allow_incoming_requests && var.enable_apigw ? 1 : 0
 
   api_key_param = var.integration.config.live_events_api_key
   target_arn    = var.allow_incoming_requests ? module.api_gateway[0].integration_webhook_api_arn : ""

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -22,7 +22,7 @@ module "port_ocean_ecs_lb" {
 
 module "port_ocean_ecs" {
   source = "../../modules/aws_helpers/ecs_service"
-  depends_on = [ module.port_ocean_ecs_lb ]
+
   subnets                                     = var.subnets
   create_ecs_cluster                          = var.create_ecs_cluster
   existing_cluster_arn                        = var.existing_cluster_arn
@@ -51,7 +51,7 @@ module "port_ocean_ecs" {
     type       = var.integration.type
     identifier = var.integration.identifier
     config = var.allow_incoming_requests ? merge({
-      app_host = module.port_ocean_ecs_lb[0].dns_name
+      app_host = module.port_ocean_ecs_lb.dns_name
     }, var.integration.config) : var.integration.config
   }
   tags = var.tags

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -24,7 +24,7 @@ module "port_ocean_ecs" {
   source = "../../modules/aws_helpers/ecs_service"
 
   subnets                                     = var.subnets
-  cluster_name                                = var.cluster_name
+  create_ecs_cluster                          = var.create_ecs_cluster
   existing_cluster_arn                        = var.existing_cluster_arn
   account_list_regions_resources_policy       = var.account_list_regions_resources_policy
   vpc_id                                      = var.vpc_id

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -22,7 +22,7 @@ module "port_ocean_ecs_lb" {
 
 module "port_ocean_ecs" {
   source = "../../modules/aws_helpers/ecs_service"
-  
+
   subnets                                     = var.subnets
   create_ecs_cluster                          = var.create_ecs_cluster
   existing_cluster_arn                        = var.existing_cluster_arn
@@ -54,7 +54,8 @@ module "port_ocean_ecs" {
       app_host = module.port_ocean_ecs_lb[0].dns_name
     }, var.integration.config) : var.integration.config
   }
-  tags = var.tags
+  additional_secrets = var.additional_secrets
+  tags               = var.tags
 }
 
 module "api_gateway" {

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -22,7 +22,7 @@ module "port_ocean_ecs_lb" {
 
 module "port_ocean_ecs" {
   source = "../../modules/aws_helpers/ecs_service"
-
+  
   subnets                                     = var.subnets
   create_ecs_cluster                          = var.create_ecs_cluster
   existing_cluster_arn                        = var.existing_cluster_arn
@@ -51,7 +51,7 @@ module "port_ocean_ecs" {
     type       = var.integration.type
     identifier = var.integration.identifier
     config = var.allow_incoming_requests ? merge({
-      app_host = module.port_ocean_ecs_lb.dns_name
+      app_host = module.port_ocean_ecs_lb[0].dns_name
     }, var.integration.config) : var.integration.config
   }
   tags = var.tags

--- a/examples/aws_container_app/variables.tf
+++ b/examples/aws_container_app/variables.tf
@@ -34,7 +34,7 @@ variable "additional_secrets" {
 
 variable "subnets" {
   type        = list(string)
-  description = "The subnets to deploy the LB to"
+  description = "List of subnet IDs where the ECS tasks and load balancer will be deployed. Use private subnets when 'is_internal' is true and public subnets when 'is_internal' is false."
 }
 
 variable "is_internal" {

--- a/examples/aws_container_app/variables.tf
+++ b/examples/aws_container_app/variables.tf
@@ -226,3 +226,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "enable_apigw" {
+  default = true
+  type = bool
+  description = "Enable API Gateway and Events module integration"
+}

--- a/examples/aws_container_app/variables.tf
+++ b/examples/aws_container_app/variables.tf
@@ -220,3 +220,9 @@ variable "account_list_regions_resources_policy" {
   default     = ["*"]
   description = "The resources to allow the task role to list regions, check out https://docs.aws.amazon.com/accounts/latest/reference/API_ListRegions.html for more information"
 }
+
+variable "tags" {
+  description = "A map of tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/examples/aws_container_app/variables.tf
+++ b/examples/aws_container_app/variables.tf
@@ -232,3 +232,10 @@ variable "enable_apigw" {
   type = bool
   description = "Enable API Gateway and Events module integration"
 }
+
+variable "create_ecs_cluster" {
+  type = bool
+  default = true
+  description = "Enable to create ECS Cluster by the module - if false provide `existing_cluster_arn` variable"
+  
+}

--- a/modules/aws_helpers/api_gateway/main.tf
+++ b/modules/aws_helpers/api_gateway/main.tf
@@ -1,12 +1,14 @@
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.rest_api_name
   description = "API Gateway for Port Ocean AWS Exporter"
+  tags        = var.tags
 }
 
 resource "aws_api_gateway_stage" "production" {
   stage_name    = "production"
   rest_api_id   = aws_api_gateway_rest_api.rest_api.id
   deployment_id = aws_api_gateway_deployment.port_ocean_exporter_gateway_deployment.id
+  tags          = var.tags
 }
 
 resource "aws_api_gateway_resource" "docs" {

--- a/modules/aws_helpers/api_gateway/variable.tf
+++ b/modules/aws_helpers/api_gateway/variable.tf
@@ -9,3 +9,9 @@ variable "webhook_url" {
   default     = "https://<your-app-url>/integration/webhook"
   description = "The webhook URL"
 }
+
+variable "tags" {
+  description = "A map of tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws_helpers/default_events/variables.tf
+++ b/modules/aws_helpers/default_events/variables.tf
@@ -8,8 +8,6 @@ variable "api_key_param" {
   description = "The API Key parameter"
 }
 
-
-#TODO: implment Variable in main.tf of module
 variable "tags" {
   description = "A map of tags to apply to all resources"
   type        = map(string)

--- a/modules/aws_helpers/default_events/variables.tf
+++ b/modules/aws_helpers/default_events/variables.tf
@@ -7,3 +7,11 @@ variable "api_key_param" {
   type        = string
   description = "The API Key parameter"
 }
+
+
+#TODO: implment Variable in main.tf of module
+variable "tags" {
+  description = "A map of tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws_helpers/ecs_lb/main.tf
+++ b/modules/aws_helpers/ecs_lb/main.tf
@@ -39,6 +39,7 @@ resource "aws_security_group" "default_ocean_sg" {
       ipv6_cidr_blocks = ["::/0"]
     }
   }
+  tags = var.tags
 }
 
 resource "aws_lb" "ocean_lb" {
@@ -48,6 +49,7 @@ resource "aws_lb" "ocean_lb" {
     var.additional_security_groups, [aws_security_group.default_ocean_sg[0].id]
   ) : var.additional_security_groups
   subnets = var.subnets
+  tags    = var.tags
 }
 
 resource "aws_lb_target_group" "ocean_tg" {
@@ -69,6 +71,7 @@ resource "aws_lb_target_group" "ocean_tg" {
   lifecycle {
     create_before_destroy = true
   }
+  tags = var.tags
 }
 
 resource "aws_lb_listener" "lb_listener" {
@@ -81,4 +84,5 @@ resource "aws_lb_listener" "lb_listener" {
   port              = local.lb_port
   protocol          = local.lb_protocol
   certificate_arn   = !local.is_certificate_domain_name_empty ? data.aws_acm_certificate.acm_certificate[0].arn : null
+  tags              = var.tags
 }

--- a/modules/aws_helpers/ecs_lb/variables.tf
+++ b/modules/aws_helpers/ecs_lb/variables.tf
@@ -25,7 +25,7 @@ variable "certificate_domain_name" {
   default     = ""
   description = "The domain name for the certificate"
 }
-
+# TODO: Variable not used
 variable "certificate_arn" {
   type        = string
   default     = ""
@@ -54,9 +54,15 @@ variable "egress_ports" {
   default     = []
   description = "The ports to allow egress traffic to"
 }
-
+# TODO: Variable not used
 variable "app_host" {
   type        = string
   default     = ""
   description = "The host url to use for the app"
+}
+
+variable "tags" {
+  description = "A map of tags to apply to all resources"
+  type        = map(string)
+  default     = {}
 }

--- a/modules/aws_helpers/ecs_service/main.tf
+++ b/modules/aws_helpers/ecs_service/main.tf
@@ -240,7 +240,7 @@ resource "aws_ecs_task_definition" "service_task_definition" {
 
 resource "aws_ecs_cluster" "port_ocean_aws_integration_cluster" {
   name  = var.cluster_name
-  count = var.existing_cluster_arn == "" ? 1 : 0
+  count = var.create_ecs_cluster ? 1 : 0
   tags  = var.tags
 }
 

--- a/modules/aws_helpers/ecs_service/variables.tf
+++ b/modules/aws_helpers/ecs_service/variables.tf
@@ -67,7 +67,7 @@ variable "ecs_use_fargate" {
 
 variable "subnets" {
   type        = list(string)
-  description = "The subnets to deploy the ECS service into"
+  description = "List of subnet IDs where the ECS tasks and load balancer will be deployed. Use private subnets when 'is_internal' is true and public subnets when 'is_internal' is false."
 }
 
 variable "existing_cluster_arn" {
@@ -178,4 +178,10 @@ variable "account_list_regions_resources_policy" {
   type        = list(string)
   default     = ["*"]
   description = "The resources to allow the task role to list regions, check out https://docs.aws.amazon.com/accounts/latest/reference/API_ListRegions.html for more information"
+}
+
+variable "tags" {
+  description = "A map of tags to apply to all resources"
+  type        = map(string)
+  default     = {}
 }

--- a/modules/aws_helpers/ecs_service/variables.tf
+++ b/modules/aws_helpers/ecs_service/variables.tf
@@ -192,3 +192,7 @@ variable "create_ecs_cluster" {
   description = "Enable to create ECS Cluster by the module - if false provide `existing_cluster_arn` variable"
   
 }
+
+variable "additional_secrets" {
+  type = map(string)
+}

--- a/modules/aws_helpers/ecs_service/variables.tf
+++ b/modules/aws_helpers/ecs_service/variables.tf
@@ -185,3 +185,10 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "create_ecs_cluster" {
+  type = bool
+  default = true
+  description = "Enable to create ECS Cluster by the module - if false provide `existing_cluster_arn` variable"
+  
+}


### PR DESCRIPTION
**What**
Implemented variables that were set in the main module but were not passed to the modules themself.
existing vars implemented:
* create_egress_default_sg
* create_default_sg
* assign_public_ip
* container_port
* additional_secrets
added vars and implemented:

- Tags
- create_ecs_cluster

**Why**
Important variables were set in the module root but not implemented in the sub-models, so they were, in fact, useless.
Also improved the ability to add an external ECS cluster instead of the module-created cluster.

**How**
passing the variables from the root module to the sub-modules without affecting the current behavior.


**Description**
Added support for tags variable across all resources.

Implemented new variables: is_internal, additional_security_groups, and create_egress_default_sg.

Enhanced ECS and ELB modules to pass and utilize additional variables.

Improved resource tagging for better management and organization.