### PR TITLE
[Fix] Adds usage of the "cpu" and "memory" variables for the ECS task

### DIFF
--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -27,6 +27,7 @@ module "port_ocean_ecs" {
   additional_task_execution_policy_statements = var.additional_task_execution_policy_statements
   additional_task_policy_statements           = var.additional_task_policy_statements
   assign_public_ip                            = var.assign_public_ip
+  cpu                                         = var.cpu
 
 
   lb_target_group_arn         = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].target_group_arn : ""
@@ -44,6 +45,7 @@ module "port_ocean_ecs" {
   integration = {
     type       = var.integration.type
     identifier = var.integration.identifier
+    cpu = var.cpu
     config = var.allow_incoming_requests ? merge({
       app_host = module.port_ocean_ecs_lb[0].dns_name
     }, var.integration.config) : var.integration.config

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -47,7 +47,7 @@ module "port_ocean_ecs" {
     type       = var.integration.type
     identifier = var.integration.identifier
     cpu        = var.cpu
-    memory        = var.memory
+    memory     = var.memory
     config = var.allow_incoming_requests ? merge({
       app_host = module.port_ocean_ecs_lb[0].dns_name
     }, var.integration.config) : var.integration.config

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -45,7 +45,7 @@ module "port_ocean_ecs" {
   integration = {
     type       = var.integration.type
     identifier = var.integration.identifier
-    cpu = var.cpu
+    cpu        = var.cpu
     config = var.allow_incoming_requests ? merge({
       app_host = module.port_ocean_ecs_lb[0].dns_name
     }, var.integration.config) : var.integration.config

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "port_ocean_ecs_lb" {
-  source                  = "port-labs/integration-factory/ocean//modules/aws_helpers/ecs_lb"
+  source                  = "../../modules/aws_helpers/ecs_lb"
   count                   = var.allow_incoming_requests ? 1 : 0
   vpc_id                  = var.vpc_id
   subnets                 = var.subnets
@@ -16,7 +16,7 @@ module "port_ocean_ecs_lb" {
 
 
 module "port_ocean_ecs" {
-  source = "port-labs/integration-factory/ocean//modules/aws_helpers/ecs_service"
+  source = "../../modules/aws_helpers/ecs_service"
 
   subnets                                     = var.subnets
   cluster_name                                = var.cluster_name
@@ -55,14 +55,14 @@ module "port_ocean_ecs" {
 }
 
 module "api_gateway" {
-  source = "port-labs/integration-factory/ocean//modules/aws_helpers/api_gateway"
+  source = "../../modules/aws_helpers/api_gateway"
   count  = var.allow_incoming_requests ? 1 : 0
 
   webhook_url = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].dns_name : ""
 }
 
 module "events" {
-  source = "port-labs/integration-factory/ocean//modules/aws_helpers/default_events"
+  source = "../../modules/aws_helpers/default_events"
   count  = var.allow_incoming_requests ? 1 : 0
 
   api_key_param = var.integration.config.live_events_api_key

--- a/examples/aws_container_app/main.tf
+++ b/examples/aws_container_app/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "port_ocean_ecs_lb" {
-  source                  = "../../modules/aws_helpers/ecs_lb"
+  source                  = "port-labs/integration-factory/ocean//modules/aws_helpers/ecs_lb"
   count                   = var.allow_incoming_requests ? 1 : 0
   vpc_id                  = var.vpc_id
   subnets                 = var.subnets
@@ -16,7 +16,7 @@ module "port_ocean_ecs_lb" {
 
 
 module "port_ocean_ecs" {
-  source = "../../modules/aws_helpers/ecs_service"
+  source = "port-labs/integration-factory/ocean//modules/aws_helpers/ecs_service"
 
   subnets                                     = var.subnets
   cluster_name                                = var.cluster_name
@@ -27,7 +27,8 @@ module "port_ocean_ecs" {
   additional_task_execution_policy_statements = var.additional_task_execution_policy_statements
   additional_task_policy_statements           = var.additional_task_policy_statements
   assign_public_ip                            = var.assign_public_ip
-  cpu                                         = var.cpu
+  cpu                                         = var.cpu       
+  memory                                      = var.memory
 
 
   lb_target_group_arn         = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].target_group_arn : ""
@@ -46,6 +47,7 @@ module "port_ocean_ecs" {
     type       = var.integration.type
     identifier = var.integration.identifier
     cpu        = var.cpu
+    memory        = var.memory
     config = var.allow_incoming_requests ? merge({
       app_host = module.port_ocean_ecs_lb[0].dns_name
     }, var.integration.config) : var.integration.config
@@ -53,14 +55,14 @@ module "port_ocean_ecs" {
 }
 
 module "api_gateway" {
-  source = "../../modules/aws_helpers/api_gateway"
+  source = "port-labs/integration-factory/ocean//modules/aws_helpers/api_gateway"
   count  = var.allow_incoming_requests ? 1 : 0
 
   webhook_url = var.allow_incoming_requests ? module.port_ocean_ecs_lb[0].dns_name : ""
 }
 
 module "events" {
-  source = "../../modules/aws_helpers/default_events"
+  source = "port-labs/integration-factory/ocean//modules/aws_helpers/default_events"
   count  = var.allow_incoming_requests ? 1 : 0
 
   api_key_param = var.integration.config.live_events_api_key


### PR DESCRIPTION
Hi Port team!

We have the need to upgrade an integration that was built using your Terraform example, the "cpu" variable was being ignored, as seen in this terraform output after including `cpu = 2048` in our .tf template.

<img width="913" alt="image" src="https://github.com/user-attachments/assets/1331cfff-58a2-48e7-a361-5ec8014c9699" />


After these fixes, the local test with the variable shows:


![image](https://github.com/user-attachments/assets/b61c930b-ed1c-4712-b99e-b8a2d280291f)
